### PR TITLE
Removed pylab from examples

### DIFF
--- a/examples/plot_hmi_lightcurve.py
+++ b/examples/plot_hmi_lightcurve.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import, division, print_function
-from pylab import *
+import matplotlib.pyplot as plt
 import example_helpers
 import drms
 
@@ -30,15 +30,15 @@ avg = res.DATAMEAN/1e3
 std = res.DATARMS/1e3
 
 # Create plot
-figure(1, figsize=(15, 7)); clf()
-title(qstr, fontsize='medium')
-fill_between(
+fig = plt.figure(figsize=(15, 7))
+ax = plt.subplot()
+ax.set_title(qstr, fontsize='medium')
+ax.fill_between(
     t, avg+std, avg-std, edgecolor='none', facecolor='b', alpha=0.3,
     interpolate=True)
-plot(t, avg, color='b')
-xlabel('Time')
-ylabel('Disk-averaged continuum intensity [kDN/s]')
-tight_layout()
-draw()
+plt.plot(t, avg, color='b')
+ax.set_xlabel('Time')
+ax.set_ylabel('Disk-averaged continuum intensity [kDN/s]')
+fig.tight_layout()
 
-show()
+plt.show()

--- a/examples/plot_hmi_lightcurve.py
+++ b/examples/plot_hmi_lightcurve.py
@@ -30,9 +30,7 @@ avg = res.DATAMEAN/1e3
 std = res.DATARMS/1e3
 
 # Create plot
-fig = plt.figure(1, figsize=(15, 7))
-fig.clf()  # avoid overplotting in interactive sessions
-ax = fig.add_subplot(111)
+fig, ax = plt.subplots(1, 1, figsize=(15, 7))
 ax.set_title(qstr, fontsize='medium')
 ax.fill_between(
     t, avg+std, avg-std, edgecolor='none', facecolor='b', alpha=0.3,

--- a/examples/plot_hmi_lightcurve.py
+++ b/examples/plot_hmi_lightcurve.py
@@ -30,13 +30,14 @@ avg = res.DATAMEAN/1e3
 std = res.DATARMS/1e3
 
 # Create plot
-fig = plt.figure(figsize=(15, 7))
-ax = plt.subplot()
+fig = plt.figure(1, figsize=(15, 7))
+fig.clf()  # avoid overplotting in interactive sessions
+ax = fig.add_subplot(111)
 ax.set_title(qstr, fontsize='medium')
 ax.fill_between(
     t, avg+std, avg-std, edgecolor='none', facecolor='b', alpha=0.3,
     interpolate=True)
-plt.plot(t, avg, color='b')
+ax.plot(t, avg, color='b')
 ax.set_xlabel('Time')
 ax.set_ylabel('Disk-averaged continuum intensity [kDN/s]')
 fig.tight_layout()

--- a/examples/plot_hmi_modes.py
+++ b/examples/plot_hmi_modes.py
@@ -48,9 +48,7 @@ elif a.shape[1] in [26, 50, 86]:
 snu = a[:, sig_offs + 2]/1e3
 
 # Plot: zoomed in on lower l
-fig = plt.figure(1, figsize=(11, 7))
-fig.clf()  # avoid overplotting in interactive sessions
-ax = fig.add_subplot(111)
+fig, ax = plt.subplots(1, 1, figsize=(11, 7))
 ax.set_title('Time = %s ... %s, L = %d ... %d, NDT = %d' % (
     k.T_START, k.T_STOP, k.LMIN, k.LMAX, k.NDT), fontsize='medium')
 for ni in np.unique(n):
@@ -61,12 +59,9 @@ ax.set_ylim(0.8, 4.5)
 ax.set_xlabel('Harmonic degree')
 ax.set_ylabel('Frequency [mHz]')
 fig.tight_layout()
-plt.draw()
 
 # Plot: higher l, n <= 20, with errors
-fig = plt.figure(2, figsize=(11, 7))
-fig.clf()  # avoid overplotting in interactive sessions
-ax = fig.add_subplot(111)
+fig, ax = plt.subplots(1, 1, figsize=(11, 7))
 ax.set_title('Time = %s ... %s, L = %d ... %d, NDT = %d' % (
     k.T_START, k.T_STOP, k.LMIN, k.LMAX, k.NDT), fontsize='medium')
 for ni in np.unique(n):
@@ -87,6 +82,5 @@ ax.set_ylim(0.8, 4.5)
 ax.set_xlabel('Harmonic degree')
 ax.set_ylabel('Frequency [mHz]')
 fig.tight_layout()
-plt.draw()
 
 plt.show()

--- a/examples/plot_hmi_modes.py
+++ b/examples/plot_hmi_modes.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
-from pylab import *
+import matplotlib.pyplot as plt
+import numpy as np
 import example_helpers
 import drms
 
@@ -32,7 +33,7 @@ fname = data_url + s[segname][0]
 
 # Read the data segment
 print('Reading data from %r...' % fname)
-a = genfromtxt(fname)
+a = np.genfromtxt(fname)
 
 # For column names, see appendix of Larson & Schou (2015SoPh..290.3221L)
 l = a[:, 0].astype(int)
@@ -47,41 +48,43 @@ elif a.shape[1] in [26, 50, 86]:
 snu = a[:, sig_offs + 2]/1e3
 
 # Plot: zoomed in on lower l
-figure(1, figsize=(11, 7)); clf()
-title('Time = %s ... %s, L = %d ... %d, NDT = %d' % (
+fig = plt.figure(1, figsize=(11, 7))
+ax = plt.subplot()
+ax.set_title('Time = %s ... %s, L = %d ... %d, NDT = %d' % (
     k.T_START, k.T_STOP, k.LMIN, k.LMAX, k.NDT), fontsize='medium')
-for ni in unique(n):
+for ni in np.unique(n):
     idx = (n == ni)
-    plot(l[idx], nu[idx], 'b.-')
-xlim(0, 120)
-ylim(0.8, 4.5)
-xlabel('Harmonic degree')
-ylabel('Frequency [mHz]')
-tight_layout()
-draw()
+    plt.plot(l[idx], nu[idx], 'b.-')
+ax.set_xlim(0, 120)
+ax.set_ylim(0.8, 4.5)
+ax.set_xlabel('Harmonic degree')
+ax.set_ylabel('Frequency [mHz]')
+fig.tight_layout()
+plt.draw()
 
 # Plot: higher l, n <= 20, with errors
-figure(2, figsize=(11, 7)); clf()
-title('Time = %s ... %s, L = %d ... %d, NDT = %d' % (
+fig = plt.figure(2, figsize=(11, 7))
+ax = plt.subplot()
+ax.set_title('Time = %s ... %s, L = %d ... %d, NDT = %d' % (
     k.T_START, k.T_STOP, k.LMIN, k.LMAX, k.NDT), fontsize='medium')
-for ni in unique(n):
+for ni in np.unique(n):
     if ni <= 20:
         idx = (n == ni)
-        plot(l[idx], nu[idx], 'b.', ms=3)
+        plt.plot(l[idx], nu[idx], 'b.', ms=3)
         if ni < 10:
-            plot(l[idx], nu[idx] + 1000*snu[idx], 'g')
-            plot(l[idx], nu[idx] - 1000*snu[idx], 'g')
+            plt.plot(l[idx], nu[idx] + 1000*snu[idx], 'g')
+            plt.plot(l[idx], nu[idx] - 1000*snu[idx], 'g')
         else:
-            plot(l[idx], nu[idx] + 500*snu[idx], 'r')
-            plot(l[idx], nu[idx] - 500*snu[idx], 'r')
-legend(loc='upper right', handles=[
-    Line2D([0], [0], color='r', label='500 sigma'),
-    Line2D([0], [0], color='g', label='1000 sigma')])
-xlim(-5, 305)
-ylim(0.8, 4.5)
-xlabel('Harmonic degree')
-ylabel('Frequency [mHz]')
-tight_layout()
-draw()
+            plt.plot(l[idx], nu[idx] + 500*snu[idx], 'r')
+            plt.plot(l[idx], nu[idx] - 500*snu[idx], 'r')
+plt.legend(loc='upper right', handles=[
+    plt.Line2D([0], [0], color='r', label='500 sigma'),
+    plt.Line2D([0], [0], color='g', label='1000 sigma')])
+ax.set_xlim(-5, 305)
+ax.set_ylim(0.8, 4.5)
+ax.set_xlabel('Harmonic degree')
+ax.set_ylabel('Frequency [mHz]')
+fig.tight_layout()
+plt.draw()
 
-show()
+plt.show()

--- a/examples/plot_hmi_modes.py
+++ b/examples/plot_hmi_modes.py
@@ -49,12 +49,13 @@ snu = a[:, sig_offs + 2]/1e3
 
 # Plot: zoomed in on lower l
 fig = plt.figure(1, figsize=(11, 7))
-ax = plt.subplot()
+fig.clf()  # avoid overplotting in interactive sessions
+ax = fig.add_subplot(111)
 ax.set_title('Time = %s ... %s, L = %d ... %d, NDT = %d' % (
     k.T_START, k.T_STOP, k.LMIN, k.LMAX, k.NDT), fontsize='medium')
 for ni in np.unique(n):
     idx = (n == ni)
-    plt.plot(l[idx], nu[idx], 'b.-')
+    ax.plot(l[idx], nu[idx], 'b.-')
 ax.set_xlim(0, 120)
 ax.set_ylim(0.8, 4.5)
 ax.set_xlabel('Harmonic degree')
@@ -64,20 +65,21 @@ plt.draw()
 
 # Plot: higher l, n <= 20, with errors
 fig = plt.figure(2, figsize=(11, 7))
-ax = plt.subplot()
+fig.clf()  # avoid overplotting in interactive sessions
+ax = fig.add_subplot(111)
 ax.set_title('Time = %s ... %s, L = %d ... %d, NDT = %d' % (
     k.T_START, k.T_STOP, k.LMIN, k.LMAX, k.NDT), fontsize='medium')
 for ni in np.unique(n):
     if ni <= 20:
         idx = (n == ni)
-        plt.plot(l[idx], nu[idx], 'b.', ms=3)
+        ax.plot(l[idx], nu[idx], 'b.', ms=3)
         if ni < 10:
-            plt.plot(l[idx], nu[idx] + 1000*snu[idx], 'g')
-            plt.plot(l[idx], nu[idx] - 1000*snu[idx], 'g')
+            ax.plot(l[idx], nu[idx] + 1000*snu[idx], 'g')
+            ax.plot(l[idx], nu[idx] - 1000*snu[idx], 'g')
         else:
-            plt.plot(l[idx], nu[idx] + 500*snu[idx], 'r')
-            plt.plot(l[idx], nu[idx] - 500*snu[idx], 'r')
-plt.legend(loc='upper right', handles=[
+            ax.plot(l[idx], nu[idx] + 500*snu[idx], 'r')
+            ax.plot(l[idx], nu[idx] - 500*snu[idx], 'r')
+ax.legend(loc='upper right', handles=[
     plt.Line2D([0], [0], color='r', label='500 sigma'),
     plt.Line2D([0], [0], color='g', label='1000 sigma')])
 ax.set_xlim(-5, 305)

--- a/examples/plot_polarfield.py
+++ b/examples/plot_polarfield.py
@@ -47,9 +47,7 @@ t = a.index.to_pydatetime()
 n, mn, sn = a.CAPN2, a_avg.CAPN2, a_std.CAPN2
 s, ms, ss = a.CAPS2, a_avg.CAPS2, a_std.CAPS2
 
-fig = plt.figure(1, figsize=(15, 7))
-fig.clf()  # avoid overplotting in interactive sessions
-ax = fig.add_subplot(111)
+fig, ax = plt.subplots(1, 1, figsize=(15, 7))
 ax.set_title(qstr, fontsize='medium')
 ax.plot(t, n, 'b', alpha=0.5, label='North pole')
 ax.plot(t, s, 'g', alpha=0.5, label='South pole')
@@ -59,11 +57,8 @@ ax.set_xlabel('Time')
 ax.set_ylabel('Mean radial field strength [G]')
 ax.legend()
 fig.tight_layout()
-plt.draw()
 
-fig = plt.figure(2, figsize=(15, 7))
-fig.clf()  # avoid overplotting in interactive sessions
-ax = fig.add_subplot(111)
+fig, ax = plt.subplots(1, 1, figsize=(15, 7))
 ax.set_title(qstr, fontsize='medium')
 ax.fill_between(
     t, mn-sn, mn+sn, edgecolor='none', facecolor='b', alpha=0.3,
@@ -77,6 +72,5 @@ ax.set_xlabel('Time')
 ax.set_ylabel('Mean radial field strength [G]')
 ax.legend()
 fig.tight_layout()
-plt.draw()
 
 plt.show()

--- a/examples/plot_polarfield.py
+++ b/examples/plot_polarfield.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
-from pylab import *
+import matplotlib.pyplot as plt
+import numpy as np
 import pandas as pd
 import example_helpers
 import drms
@@ -25,7 +26,7 @@ print(' -> %d lines retrieved.' % len(res))
 res.index = drms.to_datetime(res.pop('T_REC'))
 
 # Determine smallest timestep
-dt = diff(res.index.to_pydatetime()).min()
+dt = np.diff(res.index.to_pydatetime()).min()
 
 # Make sure the time series contains all time steps (fills gaps with NaNs)
 # Note: This does not seem to work with old pandas versions (e.g. v0.14.1)
@@ -46,32 +47,34 @@ t = a.index.to_pydatetime()
 n, mn, sn = a.CAPN2, a_avg.CAPN2, a_std.CAPN2
 s, ms, ss = a.CAPS2, a_avg.CAPS2, a_std.CAPS2
 
-figure(1, figsize=(15, 7)); clf()
-title(qstr, fontsize='medium')
-plot(t, n, 'b', alpha=0.5, label='North pole')
-plot(t, s, 'g', alpha=0.5, label='South pole')
-plot(t, mn, 'r', label='Moving average')
-plot(t, ms, 'r', label='')
-xlabel('Time')
-ylabel('Mean radial field strength [G]')
-legend()
-tight_layout()
-draw()
+fig = plt.figure(1, figsize=(15, 7))
+ax = plt.subplot()
+ax.set_title(qstr, fontsize='medium')
+plt.plot(t, n, 'b', alpha=0.5, label='North pole')
+plt.plot(t, s, 'g', alpha=0.5, label='South pole')
+plt.plot(t, mn, 'r', label='Moving average')
+plt.plot(t, ms, 'r', label='')
+ax.set_xlabel('Time')
+ax.set_ylabel('Mean radial field strength [G]')
+plt.legend()
+fig.tight_layout()
+plt.draw()
 
-figure(2, figsize=(15, 7)); clf()
-title(qstr, fontsize='medium')
+fig = plt.figure(2, figsize=(15, 7))
+ax = plt.subplot()
+ax.set_title(qstr, fontsize='medium')
 plt.fill_between(
     t, mn-sn, mn+sn, edgecolor='none', facecolor='b', alpha=0.3,
     interpolate=True)
 plt.fill_between(
     t, ms-ss, ms+ss, edgecolor='none', facecolor='g', alpha=0.3,
     interpolate=True)
-plot(t, mn, 'b', label='North pole')
-plot(t, ms, 'g', label='South pole')
-xlabel('Time')
-ylabel('Mean radial field strength [G]')
-legend()
-tight_layout()
-draw()
+plt.plot(t, mn, 'b', label='North pole')
+plt.plot(t, ms, 'g', label='South pole')
+ax.set_xlabel('Time')
+ax.set_ylabel('Mean radial field strength [G]')
+plt.legend()
+fig.tight_layout()
+plt.draw()
 
-show()
+plt.show()

--- a/examples/plot_polarfield.py
+++ b/examples/plot_polarfield.py
@@ -48,32 +48,34 @@ n, mn, sn = a.CAPN2, a_avg.CAPN2, a_std.CAPN2
 s, ms, ss = a.CAPS2, a_avg.CAPS2, a_std.CAPS2
 
 fig = plt.figure(1, figsize=(15, 7))
-ax = plt.subplot()
+fig.clf()  # avoid overplotting in interactive sessions
+ax = fig.add_subplot(111)
 ax.set_title(qstr, fontsize='medium')
-plt.plot(t, n, 'b', alpha=0.5, label='North pole')
-plt.plot(t, s, 'g', alpha=0.5, label='South pole')
-plt.plot(t, mn, 'r', label='Moving average')
-plt.plot(t, ms, 'r', label='')
+ax.plot(t, n, 'b', alpha=0.5, label='North pole')
+ax.plot(t, s, 'g', alpha=0.5, label='South pole')
+ax.plot(t, mn, 'r', label='Moving average')
+ax.plot(t, ms, 'r', label='')
 ax.set_xlabel('Time')
 ax.set_ylabel('Mean radial field strength [G]')
-plt.legend()
+ax.legend()
 fig.tight_layout()
 plt.draw()
 
 fig = plt.figure(2, figsize=(15, 7))
-ax = plt.subplot()
+fig.clf()  # avoid overplotting in interactive sessions
+ax = fig.add_subplot(111)
 ax.set_title(qstr, fontsize='medium')
-plt.fill_between(
+ax.fill_between(
     t, mn-sn, mn+sn, edgecolor='none', facecolor='b', alpha=0.3,
     interpolate=True)
-plt.fill_between(
+ax.fill_between(
     t, ms-ss, ms+ss, edgecolor='none', facecolor='g', alpha=0.3,
     interpolate=True)
-plt.plot(t, mn, 'b', label='North pole')
-plt.plot(t, ms, 'g', label='South pole')
+ax.plot(t, mn, 'b', label='North pole')
+ax.plot(t, ms, 'g', label='South pole')
 ax.set_xlabel('Time')
 ax.set_ylabel('Mean radial field strength [G]')
-plt.legend()
+ax.legend()
 fig.tight_layout()
 plt.draw()
 

--- a/examples/plot_synoptic_mr.py
+++ b/examples/plot_synoptic_mr.py
@@ -54,9 +54,7 @@ extent = (xmin - abs(k.CDELT1)/2, xmax + abs(k.CDELT1)/2,
 aspect = abs((xmax - xmin)/nx * ny/(ymax - ymin))
 
 # Create plot
-fig = plt.figure(1, figsize=(13.5, 6))
-fig.clf()  # avoid overplotting in interactive sessions
-ax = fig.add_subplot(111)
+fig, ax = plt.subplots(1, 1, figsize=(13.5, 6))
 ax.set_title('%s, Time: %s ... %s' % (qstr, k.T_START, k.T_STOP),
              fontsize='medium')
 ax.imshow(a, vmin=-300, vmax=300, origin='lower', interpolation='nearest',
@@ -65,6 +63,5 @@ ax.invert_xaxis()
 ax.set_xlabel('Carrington longitude')
 ax.set_ylabel('Sine latitude')
 fig.tight_layout()
-plt.draw()
 
 plt.show()

--- a/examples/plot_synoptic_mr.py
+++ b/examples/plot_synoptic_mr.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import, division, print_function
-from pylab import *
+import matplotlib.pyplot as plt
 from astropy.io import fits
 import example_helpers
 import drms
@@ -54,14 +54,15 @@ extent = (xmin - abs(k.CDELT1)/2, xmax + abs(k.CDELT1)/2,
 aspect = abs((xmax - xmin)/nx * ny/(ymax - ymin))
 
 # Create plot
-figure(1, figsize=(13.5, 6)); clf()
-title('%s, Time: %s ... %s' % (qstr, k.T_START, k.T_STOP), fontsize='medium')
-imshow(a, vmin=-300, vmax=300, origin='lower', interpolation='nearest',
+fig = plt.figure(1, figsize=(13.5, 6))
+ax = plt.subplot()
+ax.set_title('%s, Time: %s ... %s' % (qstr, k.T_START, k.T_STOP), fontsize='medium')
+plt.imshow(a, vmin=-300, vmax=300, origin='lower', interpolation='nearest',
        cmap='gray', extent=extent, aspect=aspect)
-gca().invert_xaxis()
-xlabel('Carrington longitude')
-ylabel('Sine latitude')
-tight_layout()
-draw()
+plt.gca().invert_xaxis()
+ax.set_xlabel('Carrington longitude')
+ax.set_ylabel('Sine latitude')
+fig.tight_layout()
+plt.draw()
 
-show()
+plt.show()

--- a/examples/plot_synoptic_mr.py
+++ b/examples/plot_synoptic_mr.py
@@ -55,11 +55,13 @@ aspect = abs((xmax - xmin)/nx * ny/(ymax - ymin))
 
 # Create plot
 fig = plt.figure(1, figsize=(13.5, 6))
-ax = plt.subplot()
-ax.set_title('%s, Time: %s ... %s' % (qstr, k.T_START, k.T_STOP), fontsize='medium')
-plt.imshow(a, vmin=-300, vmax=300, origin='lower', interpolation='nearest',
-       cmap='gray', extent=extent, aspect=aspect)
-plt.gca().invert_xaxis()
+fig.clf()  # avoid overplotting in interactive sessions
+ax = fig.add_subplot(111)
+ax.set_title('%s, Time: %s ... %s' % (qstr, k.T_START, k.T_STOP),
+             fontsize='medium')
+ax.imshow(a, vmin=-300, vmax=300, origin='lower', interpolation='nearest',
+          cmap='gray', extent=extent, aspect=aspect)
+ax.invert_xaxis()
 ax.set_xlabel('Carrington longitude')
 ax.set_ylabel('Sine latitude')
 fig.tight_layout()


### PR DESCRIPTION
pylab, though still used in many places - even within matplotlib
gallery, it's not longer recommended:

http://matplotlib.org/faq/usage_faq.html#matplotlib-pyplot-and-pylab-how-are-they-related

also it's been removed in some editors that were loading that but
default:

https://support.enthought.com/hc/en-us/articles/206698863-Enthought-Training-on-Demand-pylab-mode-vs-explicit-imports

Some people even created a pylab module, different than what the pylab
used here and if people had such thing installed by `pip install pylab`
then crashes with it.

https://github.com/javipalanca/scibag/issues/1

Thankfully now it's called `scibag` and the name conflict does not
happen to new users, though many could have been "infected" by what was
before.